### PR TITLE
bump dependency versions to 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ bench = false
 test = false
 
 [dependencies]
-flipperzero = { version = "0.12.0" }
-flipperzero-sys = { version = "0.12.0" }
-flipperzero-rt = { version = "0.12.0" }
+flipperzero = { version = "0.13.0" }
+flipperzero-sys = { version = "0.13.0" }
+flipperzero-rt = { version = "0.13.0" }


### PR DESCRIPTION
Updates the dependencies to 0.13.0 to work with the currently supported firmware version (1.1.2).