### PR TITLE
Create cargo-generate.toml to ignore images

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+exclude = ["*.png", "*.icon"]


### PR DESCRIPTION
Current master doesn't work bc cargo-generate tries to substitute things in image files.
This adds the images to the exception list.